### PR TITLE
Feature/add country tests clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,20 @@ Pull requests are welcome! If you have ideas or find bugs, feel free to open an 
 
 ---
 
+### Development Setup
+
+After cloning the repository, install the git hooks for automatic formatting and linting:
+
+```bash
+./install-hooks.sh
+```
+
+This will set up a pre-commit hook that:
+- Automatically formats all Dart files
+- Runs dart analyze to check for issues
+- Prevents commits if there are analysis errors
+
+
 ## 👋 Author
 
 Maintained by [Franklin Oladipo](https://github.com/frankdroid7)

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Pre-commit hook for Dart formatting and linting
+
+echo "Running Dart formatter..."
+
+# Check if any files need formatting
+if ! dart format --set-exit-if-changed . > /dev/null 2>&1; then
+    echo "Some files were not formatted. Auto-formatting now..."
+    dart format .
+    git add .
+fi
+
+echo "Running Dart analyzer..."
+
+# Analyze with fatal-infos (same as CI)
+if ! dart analyze --fatal-infos; then
+    echo "Dart analyzer found issues. Fix them before committing."
+    exit 1
+fi
+
+echo "Pre-commit checks passed!"
+exit 0

--- a/install-hooks.sh
+++ b/install-hooks.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Script to install git hooks
+
+echo "Installing git hooks..."
+
+# Copy pre-commit hook
+cp hooks/pre-commit .git/hooks/pre-commit
+
+# Make it executable
+chmod +x .git/hooks/pre-commit
+
+echo " Git hooks installed successfully!"
+echo "The pre-commit hook will now:"
+echo "  - Format all Dart files automatically"
+echo "  - Run dart analyze to check for issues"
+echo "  - Prevent commits if there are analysis errors"

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -95,6 +95,21 @@ void main() {
         expect(result, isA<List<Map<String, dynamic>>>());
       },
     );
+
+    test(
+      'GIVEN currency endpoint, WHEN callAPI is called with valid currency, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url = 'https://restcountries.com/v3.1/currency/usd';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(mockData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
   });
 }
 

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -171,6 +171,21 @@ void main() {
         expect(result, isA<List<Map<String, dynamic>>>());
       },
     );
+
+    test(
+      'GIVEN translation endpoint, WHEN callAPI is called with valid translation, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url = 'https://restcountries.com/v3.1/translation/france';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(mockData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
   });
 }
 

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -80,6 +80,21 @@ void main() {
         expect(result, isA<List<Map<String, dynamic>>>());
       },
     );
+
+    test(
+      'GIVEN country code endpoint, WHEN callAPI is called with valid code, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url = 'https://restcountries.com/v3.1/alpha/ng';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(nigeriaData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
   });
 }
 

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -201,6 +201,25 @@ void main() {
         expect(result, isA<List<Map<String, dynamic>>>());
       },
     );
+
+    test(
+      'GIVEN invalid country name, WHEN callAPI is called, THEN throw a country not found exception',
+      () async {
+        final String url = 'https://restcountries.com/v3.1/name/invalidcountry';
+        when(() => mockApiHelper.callAPI(apiUrl: url))
+            .thenThrow(Exception('Country not found'));
+
+        expect(
+          () => mockApiHelper.callAPI(apiUrl: url),
+          throwsA(
+            predicate(
+              (Object? e) =>
+                  e is Exception && e.toString().contains('Country not found'),
+            ),
+          ),
+        );
+      },
+    );
   });
 }
 

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -186,6 +186,21 @@ void main() {
         expect(result, isA<List<Map<String, dynamic>>>());
       },
     );
+
+    test(
+      'GIVEN demonym endpoint, WHEN callAPI is called with valid demonym, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url = 'https://restcountries.com/v3.1/demonym/american';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(mockData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
   });
 }
 

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -110,6 +110,21 @@ void main() {
         expect(result, isA<List<Map<String, dynamic>>>());
       },
     );
+
+    test(
+      'GIVEN language endpoint, WHEN callAPI is called with valid language, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url = 'https://restcountries.com/v3.1/lang/french';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(mockData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
   });
 }
 

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -155,6 +155,22 @@ void main() {
         expect(result, isA<List<Map<String, dynamic>>>());
       },
     );
+
+    test(
+      'GIVEN subregion endpoint, WHEN callAPI is called with valid subregion, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url =
+            'https://restcountries.com/v3.1/subregion/western%20africa';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(mockData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
   });
 }
 

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -140,6 +140,21 @@ void main() {
         expect(result, isA<List<Map<String, dynamic>>>());
       },
     );
+
+    test(
+      'GIVEN region endpoint, WHEN callAPI is called with valid region, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url = 'https://restcountries.com/v3.1/region/africa';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(mockData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
   });
 }
 

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -220,6 +220,85 @@ void main() {
         );
       },
     );
+
+    test(
+      'GIVEN independent status endpoint, WHEN callAPI is called with independent status, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url =
+            'https://restcountries.com/v3.1/independent?status=true';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(mockData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
+
+    test(
+      'GIVEN calling code endpoint, WHEN callAPI is called with valid calling code, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url = 'https://restcountries.com/v3.1/callingcode/234';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(nigeriaData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
+
+    test(
+      'GIVEN full name endpoint, WHEN callAPI is called with full country name, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url =
+            'https://restcountries.com/v3.1/name/federal%20republic%20of%20nigeria?fullText=true';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(nigeriaData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
+
+    test(
+      'GIVEN multiple alpha codes endpoint, WHEN callAPI is called with multiple codes, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url =
+            'https://restcountries.com/v3.1/alpha?codes=ng,gh,bj';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(mockData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
+
+    test(
+      'GIVEN fields filter endpoint, WHEN callAPI is called with specific fields, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url =
+            'https://restcountries.com/v3.1/all?fields=name,capital,population';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(mockData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
   });
 }
 

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -65,8 +65,35 @@ void main() {
         );
       },
     );
+
+    test(
+      'GIVEN country name endpoint, WHEN callAPI is called with valid name, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url = 'https://restcountries.com/v3.1/name/nigeria';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(nigeriaData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
   });
 }
+
+String nigeriaData = """[
+  {
+    "name": {
+      "common": "Nigeria",
+      "official": "Federal Republic of Nigeria",
+      "nativeName": {
+        "eng": {"official": "Federal Republic of Nigeria", "common": "Nigeria"}
+      }
+    }
+  }
+]""";
 
 String mockData = """[
   {

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -299,6 +299,46 @@ void main() {
         expect(result, isA<List<Map<String, dynamic>>>());
       },
     );
+
+    test(
+      'GIVEN invalid currency code, WHEN callAPI is called, THEN throw an exception',
+      () async {
+        final String url =
+            'https://restcountries.com/v3.1/currency/invalidcurrency';
+        when(() => mockApiHelper.callAPI(apiUrl: url))
+            .thenThrow(Exception('Currency not found'));
+
+        expect(
+          () => mockApiHelper.callAPI(apiUrl: url),
+          throwsA(
+            predicate(
+              (Object? e) =>
+                  e is Exception && e.toString().contains('Currency not found'),
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'GIVEN invalid alpha code, WHEN callAPI is called, THEN throw an exception',
+      () async {
+        final String url = 'https://restcountries.com/v3.1/alpha/xyz';
+        when(() => mockApiHelper.callAPI(apiUrl: url))
+            .thenThrow(Exception('Invalid country code'));
+
+        expect(
+          () => mockApiHelper.callAPI(apiUrl: url),
+          throwsA(
+            predicate(
+              (Object? e) =>
+                  e is Exception &&
+                  e.toString().contains('Invalid country code'),
+            ),
+          ),
+        );
+      },
+    );
   });
 }
 

--- a/test/src/data/api_helper_test.dart
+++ b/test/src/data/api_helper_test.dart
@@ -125,6 +125,21 @@ void main() {
         expect(result, isA<List<Map<String, dynamic>>>());
       },
     );
+
+    test(
+      'GIVEN capital endpoint, WHEN callAPI is called with valid capital, THEN return a List<Map<String, dynamic>>',
+      () async {
+        final String url = 'https://restcountries.com/v3.1/capital/london';
+        when(() => mockApiHelper.callAPI(apiUrl: url)).thenAnswer((_) =>
+            Future<List<Map<String, dynamic>>>.value(
+                List<Map<String, dynamic>>.from(jsonDecode(mockData))));
+
+        List<Map<String, dynamic>> result =
+            await mockApiHelper.callAPI(apiUrl: url);
+
+        expect(result, isA<List<Map<String, dynamic>>>());
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Add REST Countries API Endpoint Tests

### Summary
Adds 10 comprehensive tests for REST Countries API endpoints covering all major query types and a pre-hook commit for formatting and linting

### Changes
- **API Endpoint Tests** (13 total tests in `api_helper_test.dart`):
  - `/all` - Get all countries
  - `/name/{name}` - Search by country name
  - `/alpha/{code}` - Search by country code
  - `/currency/{currency}` - Filter by currency
  - `/lang/{language}` - Filter by language
  - `/capital/{capital}` - Search by capital city
  - `/region/{region}` - Filter by region
  - `/subregion/{subregion}` - Filter by subregion
  - `/translation/{translation}` - Search by translation
  - `/demonym/{demonym}` - Search by demonym
  - Exception handling for invalid countries